### PR TITLE
remove js classes for click event from divs where they're not need

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
 </head>
 
 
-<body class="js-menu-close">
-    <div id="sidebar-wrapper"  class="js-menu-open">
+<body>
+    <div id="sidebar-wrapper">
 
         <h2>Spike</h2>
         <h2>Spiegel</h2>


### PR DESCRIPTION
Hey Oliver —

I finally had a chance to look into why your link tags weren't working. Turns out, you had added the classes "js-menu-open" and "js-menu-close" to the body and the menu div, so the javascript was just constantly listening for those click events...even when you clicked on an <a> tag specifically. In my branch, I've removed those extraneous classes and I think it's working as expected.

- Melissa